### PR TITLE
Fix crypto random generation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,17 +280,22 @@ The `encryptCompressEncode()` and `decodeDecompressDecrypt()` functions of the `
 
 You will need an `iv` and `key` to encrypt the `str` argument:
 
-1. Note that we we are generating a 128-bit key length because it results in a shorter shareable ID string that we place in a shareable URL. (You can generate a key with a 256-bit key length by using a 32-byte initialization vector, i.e. `iv`.):
+1. Note that we are generating a 128-bit key length because it results in a shorter shareable ID string that we place in a shareable URL. (You can generate a key with a 256-bit key length by using a 32-byte initialization vector, i.e. `iv`.):
 
    ```ts
-   // 1. Set the size of the key to 16 bytes
+   // 1. Set the size of the IV to 16 bytes
    const bytesSize = new Uint8Array(16)
    
    // 2. Create an initialization vector of 128 bit-length
-   const iv = crypto.getRandomValues(bytesSize).toString()
+   if (crypto.webcrypto?.getRandomValues) {
+     crypto.webcrypto.getRandomValues(bytesSize)
+   } else {
+     crypto.randomFillSync(bytesSize)
+   }
+   const iv = bytesSize.toString()
    console.log(`iv:`, iv)
 
-   // 3. Generate a new asymmetric key
+   // 3. Generate a new symmetric key
    const key = await crypto.subtle.generateKey(
    {
          name: 'AES-GCM',

--- a/__test__/generate-client-crypto-key.test.ts
+++ b/__test__/generate-client-crypto-key.test.ts
@@ -7,8 +7,12 @@ describe('ClientCrypto Initialization Vector and Key Generation', () => {
     const bytesSize = new Uint8Array(16)
 
     // 2. Create an initialization vector of 128 bit-length
-    const iv = crypto.getRandomValues(bytesSize)
-    console.log(`iv:`, iv.toString())
+    if (crypto.webcrypto?.getRandomValues) {
+      crypto.webcrypto.getRandomValues(bytesSize)
+    } else {
+      crypto.randomFillSync(bytesSize)
+    }
+    const iv = bytesSize
 
     // 3. Generate a new symmetric key (AES-GCM, 128 bits)
     const key = await crypto.subtle.generateKey(
@@ -23,11 +27,12 @@ describe('ClientCrypto Initialization Vector and Key Generation', () => {
     // 4. Export the `CryptoKey`
     const jwk = await crypto.subtle.exportKey('jwk', key)
     const serializedJwk = JSON.stringify(jwk)
-    console.log(`serializedJwk:`, serializedJwk)
 
     // Optionally, add assertions
+    expect(iv.length).toBe(16)
+    expect((key as CryptoKey).algorithm.name).toBe('AES-GCM')
     expect(jwk.kty).toBe('oct')
     expect(jwk.k).toBeDefined()
     expect(jwk.alg).toBe('A128GCM')
   })
-}) 
+})


### PR DESCRIPTION
## Summary
- update README crypto snippet to prefer `crypto.webcrypto.getRandomValues` and fall back to `crypto.randomFillSync`
- adjust test to use Node's random source and verify IV length and key algorithm
- fix README snippet grammar

## Testing
- `npm test`
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846e51065c883318b9a7f10db9e76e9