### PR TITLE
Fix typos in node crypto comments

### DIFF
--- a/src/lib/node-crypto/index.ts
+++ b/src/lib/node-crypto/index.ts
@@ -47,7 +47,7 @@ export class ServerCrypto {
     //   {
     //     N: 16384, // CPU/memory cost, i.e. level of brute-force attack reststance
     //     r: 8, // block size (higher values are more secure)
-    //     p: 1, // level of resistance to paralel attacks
+    //     p: 1, // level of resistance to parallel attacks
     //     maxmem: 32 * 1024 * 1024, // limits the amount of memory used
     //   }
     // )
@@ -193,7 +193,7 @@ export class ServerCrypto {
 /**
  * @dev Client-side cryptography using Node.js's built-in `crypto.subtle` 
  *      library
- * @notice See the `README.md` for how to generate an asymmmetric key and 
+ * @notice See the `README.md` for how to generate an asymmetric key and
  *         initialization vector to use the `encryptThenEncode` and 
  *         `decodeThenDecrypt` functions.
  */


### PR DESCRIPTION
## Summary
- fix typo `paralel` → `parallel`
- fix typo `asymmmetric` → `asymmetric`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ff39cb4083318a0bd9eec89c20f8