### PR TITLE
Fix typo in node crypto comments

### DIFF
--- a/src/lib/node-crypto/index.ts
+++ b/src/lib/node-crypto/index.ts
@@ -45,7 +45,7 @@ export class ServerCrypto {
     //   this.salt,
     //   SSCrypto.ENCRYPTION_KEY_LENGTH,
     //   {
-    //     N: 16384, // CPU/memory cost, i.e. level of brute-force attack reststance
+    //     N: 16384, // CPU/memory cost, i.e. level of brute-force attack resistance
     //     r: 8, // block size (higher values are more secure)
     //     p: 1, // level of resistance to parallel attacks
     //     maxmem: 32 * 1024 * 1024, // limits the amount of memory used


### PR DESCRIPTION
## Summary
- correct a misspelling in `src/lib/node-crypto/index.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471b85bc2083319c88a89f0c49a28f